### PR TITLE
added coverage config in jest.config.ts and added errorCatch test

### DIFF
--- a/aws-node-appsync/.gitignore
+++ b/aws-node-appsync/.gitignore
@@ -11,3 +11,7 @@ package-lock.json
 .env
 yarn-error.log
 __tests__/test-report.html
+__tests__/coverage
+
+.DS_Store
+

--- a/aws-node-appsync/__tests__/jest.config.ts
+++ b/aws-node-appsync/__tests__/jest.config.ts
@@ -25,6 +25,10 @@ const config: Config.InitialOptions = {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
   watchPathIgnorePatterns: ['<rootDir>/.serverless/', '<rootDir>/dist/', '<rootDir>/node_modules/', '<rootDir>/src/'],
+  rootDir: '../',
+  collectCoverage: false, // 常にカバレッジを取得する場合はtrueにする
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts', '!src/**/*.test.ts', '!src/**/*.spec.ts', '!src/types/**/*.ts'],
+  coverageDirectory: '__tests__/coverage',
 };
 
 export default config;

--- a/aws-node-appsync/__tests__/src/middlewares/middy/errorCatch.spec.ts
+++ b/aws-node-appsync/__tests__/src/middlewares/middy/errorCatch.spec.ts
@@ -1,0 +1,18 @@
+import { AppSyncResolverEvent, Context } from 'aws-lambda';
+import middy from 'utils/middy';
+import logger from 'utils/logger';
+
+describe('errorCatch', () => {
+  it('should catch error', async () => {
+    const mockErrorFn = jest.fn();
+    logger.error = mockErrorFn;
+    const handler = middy.handler(async () => {
+      await Promise.reject(new Error('test'));
+    });
+
+    await expect(handler({} as AppSyncResolverEvent<unknown>, {} as Context)).rejects.toThrow('test');
+    expect(mockErrorFn.mock.calls).toHaveLength(1);
+    console.log(mockErrorFn.mock.calls[0]);
+    expect((mockErrorFn.mock.calls[0] as { error: Error }[])[0].error).toHaveProperty('message', 'test');
+  });
+});

--- a/aws-node-appsync/package.json
+++ b/aws-node-appsync/package.json
@@ -6,7 +6,7 @@
     "node": ">=18.x"
   },
   "scripts": {
-    "test": "jest --config __tests__/jest.config.ts --all",
+    "test": "jest --config __tests__/jest.config.ts",
     "env:dev": "cp env/dev.env ./.env",
     "env:stg": "cp env/stg.env ./.env",
     "env:prd": "cp env/prd.env ./.env",


### PR DESCRIPTION
# Added coverage configuration in jest.config.ts
- Fix rootDir
- Files to measure and files to ignore
- Export result directory
# Added errorCatch test file
- Add test that expects error messages to be passed to the log